### PR TITLE
Fix discovery of non-QtWidgets includes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ deps = [
   dependency('libavcodec'),
   dependency('libavformat'),
   dependency('libavutil'),
-  dependency('qt5', modules: 'Widgets')
+  dependency('qt5', modules: ['Core', 'GUI', 'Widgets'])
 ]
 
 moc_headers = [


### PR DESCRIPTION
When Qt libs/headers aren't in toolchain-default paths, they won't get picked up for the build and errors will result.

Fixes inclusion of QSettings and others in macOS builds with homebrewed deps.